### PR TITLE
Fix invalid class passed to getLogger

### DIFF
--- a/src/main/java/com/networknt/schema/AnyOfValidator.java
+++ b/src/main/java/com/networknt/schema/AnyOfValidator.java
@@ -26,7 +26,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class AnyOfValidator extends BaseJsonValidator {
-    private static final Logger logger = LoggerFactory.getLogger(RequiredValidator.class);
+    private static final Logger logger = LoggerFactory.getLogger(AnyOfValidator.class);
     private static final String DISCRIMINATOR_REMARK = "and the discriminator-selected candidate schema didn't pass validation";
 
     private final List<JsonSchema> schemas = new ArrayList<>();

--- a/src/main/java/com/networknt/schema/ExclusiveMinimumValidator.java
+++ b/src/main/java/com/networknt/schema/ExclusiveMinimumValidator.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.Set;
 
 public class ExclusiveMinimumValidator extends BaseJsonValidator {
-    private static final Logger logger = LoggerFactory.getLogger(MinimumValidator.class);
+    private static final Logger logger = LoggerFactory.getLogger(ExclusiveMinimumValidator.class);
 
     /**
      * In order to limit number of `if` statements in `validate` method, all the

--- a/src/main/java/com/networknt/schema/NotValidator.java
+++ b/src/main/java/com/networknt/schema/NotValidator.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 public class NotValidator extends BaseJsonValidator {
-    private static final Logger logger = LoggerFactory.getLogger(RequiredValidator.class);
+    private static final Logger logger = LoggerFactory.getLogger(NotValidator.class);
 
     private final JsonSchema schema;
 


### PR DESCRIPTION
`getLogger` parameter should match class name, where the logger is declared.

